### PR TITLE
ci(release): add conventionalcommits preset to semantic-release

### DIFF
--- a/.releaserc.json
+++ b/.releaserc.json
@@ -2,7 +2,10 @@
   "branches": ["main"],
   "tagFormat": "${version}",
   "plugins": [
-    "@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer", {
+      "preset": "conventionalcommits"
+    }],
     [
       "@google/semantic-release-replace-plugin",
       {
@@ -66,7 +69,10 @@
         ]
       }
     ],
-    "@semantic-release/release-notes-generator",
+    [
+      "@semantic-release/release-notes-generator", {
+      "preset": "conventionalcommits"
+    }],
     [
       "@semantic-release/changelog",
       {
@@ -93,6 +99,5 @@
         "message": "chore(release): ${nextRelease.version}"
       }
     ]
-  ],
-  "preset": "conventionalcommits"
+  ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -93,5 +93,6 @@
         "message": "chore(release): ${nextRelease.version}"
       }
     ]
-  ]
+  ],
+  "preset": "conventionalcommits"
 }

--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ SEMANTIC_RELEASE=npx --yes \
 	-p "@semantic-release/github" \
 	-p "@semantic-release/git" \
 	-p "@google/semantic-release-replace-plugin" \
+	-p @semantic-release/conventional-commits \
 	semantic-release
 
 

--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,8 @@ SEMANTIC_RELEASE=npx --yes \
 	-p "@semantic-release/github" \
 	-p "@semantic-release/git" \
 	-p "@google/semantic-release-replace-plugin" \
-	-p @semantic-release/conventional-commits \
+	-p @commitlint/cli \
+	-p @commitlint/config-conventional \
 	semantic-release
 
 


### PR DESCRIPTION
fix #69 

# PR Checklist

Ensure that:

- it includes tests.
- the tests for your implementation are executed on CI.
- it includes documentation
- the PR's title is according to the [semantic-release pattern][semantic-release-message].
  - `build`: Changes that affect the build system or external dependencies (example scopes: cmake, meson, etc)
  - `ci`: Changes to our CI configuration files and scripts (examples: CircleCi, SauceLabs)
  - `docs`: Documentation only changes
  - `perf`: A code change that improves performance
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `test`: Adding missing tests or correcting existing tests
  - `chore:` Can be used as a generic task for tasks such as CI, test, support tasks or any other task that is not user facing task.
  - `feat:` is used for a new feature or when a existent one is improved.
  - `fix:` is used when a bug is fixed.
  - `BREAKING CHANGE:` is used when there is a compatibility break.
- pre-commit hooks were executed locally


<!-- Add any other extra information that would help to understand the changes proposed by the PR -->


[semantic-release-message]: https://github.com/semantic-release/semantic-release/blob/master/README.md#commit-message-format "Semantic Release Commit Message Format"

NOTES:

pre-commit hook `clang-tidy` is not working properly.
logs:
<details>
<code>
clang-tidy...............................................................Failed
- hook id: clang-tidy
- exit code: 134

+ TMP_DIR=/tmp/arx
+ mkdir -p /tmp/arx
+ cp /home/luabida/Projetos/OSL/arx/artifacts/compile_commands.json.tmpl /tmp/arx/compile_commands.json
+ sed -i 's:{{PROJECT_PATH}}:/home/luabida/Projetos/OSL/arx:g' /tmp/arx/compile_commands.json
+ sed -i 's:{{CONDA_PREFIX}}:/home/luabida/micromamba/envs/arx:g' /tmp/arx/compile_commands.json
+ clang-tidy --config-file=/home/luabida/Projetos/OSL/arx/.clang-tidy --header-filter=/home/luabida/micromamba/envs/arx/include --extra-arg=-I/home/luabida/Projetos/OSL/arx/src -p=/tmp/arx /home/luabida/Projetos/OSL/arx/src/error.cpp /home/luabida/Projetos/OSL/arx/src/io.cpp /home/luabida/Projetos/OSL/arx/src/lexer.cpp /home/luabida/Projetos/OSL/arx/src/main.cpp /home/luabida/Projetos/OSL/arx/src/parser.cpp /home/luabida/Projetos/OSL/arx/src/utils.cpp /home/luabida/Projetos/OSL/arx/src/error.h /home/luabida/Projetos/OSL/arx/src/io.h /home/luabida/Projetos/OSL/arx/src/jit.h /home/luabida/Projetos/OSL/arx/src/lexer.h /home/luabida/Projetos/OSL/arx/src/parser.h /home/luabida/Projetos/OSL/arx/src/utils.h /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-object.cpp /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-output.cpp /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-object.h /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-output.h
LLVM ERROR: Cannot chdir into "/home/luabida/Projetos/OSL/arx/build"!
PLEASE submit a bug report to https://github.com/llvm/llvm-project/issues/ and include the crash backtrace.
Stack dump:
0.      Program arguments: clang-tidy --config-file=/home/luabida/Projetos/OSL/arx/.clang-tidy --header-filter=/home/luabida/micromamba/envs/arx/include --extra-arg=-I/home/luabida/Projetos/OSL/arx/src -p=/tmp/arx /home/luabida/Projetos/OSL/arx/src/error.cpp /home/luabida/Projetos/OSL/arx/src/io.cpp /home/luabida/Projetos/OSL/arx/src/lexer.cpp /home/luabida/Projetos/OSL/arx/src/main.cpp /home/luabida/Projetos/OSL/arx/src/parser.cpp /home/luabida/Projetos/OSL/arx/src/utils.cpp /home/luabida/Projetos/OSL/arx/src/error.h /home/luabida/Projetos/OSL/arx/src/io.h /home/luabida/Projetos/OSL/arx/src/jit.h /home/luabida/Projetos/OSL/arx/src/lexer.h /home/luabida/Projetos/OSL/arx/src/parser.h /home/luabida/Projetos/OSL/arx/src/utils.h /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-object.cpp /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-output.cpp /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-object.h /home/luabida/Projetos/OSL/arx/src/codegen/ast-to-output.h
 #0 0x00007f2df61e8532 PrintStackTraceSignalHandler(void*) Signals.cpp:0:0
 #1 0x00007f2df61e5c7e SignalHandler(int) Signals.cpp:0:0
 #2 0x00007f2df4f79520 (/lib/x86_64-linux-gnu/libc.so.6+0x42520)
 #3 0x00007f2df4fcda7c __pthread_kill_implementation ./nptl/pthread_kill.c:44:76
 #4 0x00007f2df4fcda7c __pthread_kill_internal ./nptl/pthread_kill.c:78:10
 #5 0x00007f2df4fcda7c pthread_kill ./nptl/pthread_kill.c:89:10
 #6 0x00007f2df4f79476 gsignal ./signal/../sysdeps/posix/raise.c:27:6
 #7 0x00007f2df4f5f7f3 abort ./stdlib/abort.c:81:7
 #8 0x00007f2df5f491a9 llvm::json::operator==(llvm::json::Value const&, llvm::json::Value const&) (.cold) JSON.cpp:0:0
 #9 0x00007f2dff765a64 clang::tooling::ClangTool::run(clang::tooling::ToolAction*) (/home/luabida/micromamba/envs/arx/bin/../lib/libclang-cpp.so.15+0x2ae0a64)
#10 0x000055d4b47c592f clang::tidy::runClangTidy(clang::tidy::ClangTidyContext&, clang::tooling::CompilationDatabase const&, llvm::ArrayRef<std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char>>>, llvm::IntrusiveRefCntPtr<llvm::vfs::OverlayFileSystem>, bool, bool, llvm::StringRef) (/home/luabida/micromamba/envs/arx/bin/clang-tidy-15+0x12be92f)
#11 0x000055d4b3bcd865 clang::tidy::clangTidyMain(int, char const**) (/home/luabida/micromamba/envs/arx/bin/clang-tidy-15+0x6c6865)
#12 0x00007f2df4f60d90 __libc_start_call_main ./csu/../sysdeps/nptl/libc_start_call_main.h:58:16
#13 0x00007f2df4f60e40 call_init ./csu/../csu/libc-start.c:128:20
#14 0x00007f2df4f60e40 __libc_start_main ./csu/../csu/libc-start.c:379:5
#15 0x000055d4b3bc37fd _start (/home/luabida/micromamba/envs/arx/bin/clang-tidy-15+0x6bc7fd)
./scripts/run-clang-tidy.sh: line 22: 22337 Aborted                 (core dumped) clang-tidy --config-file="${PROJECT_PATH}/.clang-tidy" --header-filter="${CONDA_PREFIX}/include" --extra-arg="-I${PROJECT_PATH}/src" -p="${TMP_DIR}" ${PROJECT_PATH}/src/*.cpp ${PROJECT_PATH}/src/*.h ${PROJECT_PATH}/src/codegen/*.cpp ${PROJECT_PATH}/src/codegen/*.h
</code>
</details>
