### PR TITLE
refactor: Add initial support for datatypes

### DIFF
--- a/examples/average.arx
+++ b/examples/average.arx
@@ -1,2 +1,2 @@
-function average(x y):
+function average(x, y):
   (x + y) * 0.5;

--- a/examples/sum.arx
+++ b/examples/sum.arx
@@ -1,2 +1,2 @@
-function sum(a b):
+function sum(a, b):
   a + b;

--- a/src/codegen/arx-llvm.cpp
+++ b/src/codegen/arx-llvm.cpp
@@ -1,8 +1,13 @@
+#include <string>
 
-#include <llvm/IR/DIBuilder.h>   // for DIBuilder
-#include <llvm/IR/IRBuilder.h>   // for IRBuilder
-#include <llvm/IR/Module.h>      // for Module
-#include <llvm/Support/Error.h>  // for ExitOnError
+#include <glog/logging.h>               // for COMPACT_GOOGLE_LOG_INFO, LOG
+#include <llvm/IR/DIBuilder.h>          // for DIBuilder
+#include <llvm/IR/IRBuilder.h>          // for IRBuilder
+#include <llvm/IR/Module.h>             // for Module
+#include <llvm/Support/Error.h>         // for ExitOnError
+#include <llvm/Support/TargetSelect.h>  // for InitializeAllAsmParsers, Init...
+#include <llvm/Target/TargetMachine.h>  // for TargetMachine
+#include <llvm/Target/TargetOptions.h>  // for TargetOptions
 
 #include "codegen/arx-llvm.h"  // for ArxLLVM
 #include "codegen/jit.h"       // for ArxJIT
@@ -22,6 +27,7 @@ llvm::Type* ArxLLVM::FLOAT_TYPE;
 llvm::Type* ArxLLVM::DOUBLE_TYPE;
 llvm::Type* ArxLLVM::INT8_TYPE;
 llvm::Type* ArxLLVM::INT32_TYPE;
+llvm::Type* ArxLLVM::VOID_TYPE;
 
 /* Debug Information Data types */
 llvm::DIType* ArxLLVM::DI_FLOAT_TYPE;
@@ -30,9 +36,9 @@ llvm::DIType* ArxLLVM::DI_INT8_TYPE;
 llvm::DIType* ArxLLVM::DI_INT32_TYPE;
 llvm::DIType* ArxLLVM::DI_VOID_TYPE;
 
-extern bool IS_BUILD_LIB = false;  // default value
+llvm::ExitOnError ArxLLVM::exit_on_err;
 
-llvm::Type* ArxLLVM::VOID_TYPE;
+extern bool IS_BUILD_LIB = false;  // default value
 
 auto ArxLLVM::get_data_type(std::string type_name) -> llvm::Type* {
   if (type_name == "float") {
@@ -70,4 +76,51 @@ auto ArxLLVM::get_di_data_type(std::string di_type_name) -> llvm::DIType* {
 
   llvm::errs() << "[EE] di_type_name not valid.\n";
   return nullptr;
+}
+
+auto ArxLLVM::initialize() -> void {
+  // initialize the target registry etc.
+  llvm::InitializeAllTargetInfos();
+  llvm::InitializeAllTargets();
+  llvm::InitializeAllTargetMCs();
+  llvm::InitializeAllAsmParsers();
+  llvm::InitializeAllAsmPrinters();
+
+  llvm::InitializeNativeTarget();
+  llvm::InitializeNativeTargetAsmPrinter();
+  llvm::InitializeNativeTargetAsmParser();
+
+  ArxLLVM::context = std::make_unique<llvm::LLVMContext>();
+  ArxLLVM::module =
+    std::make_unique<llvm::Module>("arx jit", *ArxLLVM::context);
+
+  // Create a new builder for the module.
+  ArxLLVM::ir_builder = std::make_unique<llvm::IRBuilder<>>(*ArxLLVM::context);
+
+  // Data Types
+  ArxLLVM::FLOAT_TYPE = llvm::Type::getFloatTy(*ArxLLVM::context);
+  ArxLLVM::DOUBLE_TYPE = llvm::Type::getDoubleTy(*ArxLLVM::context);
+  ArxLLVM::INT8_TYPE = llvm::Type::getInt8Ty(*ArxLLVM::context);
+  ArxLLVM::INT32_TYPE = llvm::Type::getInt32Ty(*ArxLLVM::context);
+  ArxLLVM::VOID_TYPE = llvm::Type::getVoidTy(*ArxLLVM::context);
+
+  LOG(INFO) << "initialize Target";
+
+  // LLVM IR
+
+  ArxLLVM::jit = ArxLLVM::exit_on_err(llvm::orc::ArxJIT::Create());
+  ArxLLVM::module->setDataLayout(ArxLLVM::jit->get_data_layout());
+
+  // Create a new builder for the module.
+  ArxLLVM::di_builder = std::make_unique<llvm::DIBuilder>(*ArxLLVM::module);
+
+  // di data types
+  ArxLLVM::DI_FLOAT_TYPE = ArxLLVM::di_builder->createBasicType(
+    "float", 32, llvm::dwarf::DW_ATE_float);
+  ArxLLVM::DI_DOUBLE_TYPE = ArxLLVM::di_builder->createBasicType(
+    "double", 64, llvm::dwarf::DW_ATE_float);
+  ArxLLVM::DI_INT8_TYPE = ArxLLVM::di_builder->createBasicType(
+    "int8", 8, llvm::dwarf::DW_ATE_signed);
+  ArxLLVM::DI_INT32_TYPE = ArxLLVM::di_builder->createBasicType(
+    "int32", 32, llvm::dwarf::DW_ATE_signed);
 }

--- a/src/codegen/arx-llvm.h
+++ b/src/codegen/arx-llvm.h
@@ -19,6 +19,8 @@ class ArxLLVM {
   static std::map<std::string, llvm::AllocaInst*> named_values;
   static std::map<std::string, std::unique_ptr<PrototypeAST>> function_protos;
 
+  static llvm::ExitOnError exit_on_err;
+
   /* Data types */
   static llvm::Type* DOUBLE_TYPE;
   static llvm::Type* FLOAT_TYPE;
@@ -35,6 +37,7 @@ class ArxLLVM {
 
   static auto get_data_type(std::string type_name) -> llvm::Type*;
   static auto get_di_data_type(std::string type_name) -> llvm::DIType*;
+  static auto initialize() -> void;
 };
 
 extern bool IS_BUILD_LIB;

--- a/src/codegen/ast-to-object.cpp
+++ b/src/codegen/ast-to-object.cpp
@@ -92,13 +92,16 @@ auto ASTToObjectVisitor::getFunction(std::string name) -> void {
  * @param var_name The variable name
  * @return An llvm allocation instance.
  *
- * CreateEntryBlockAlloca - Create an alloca instruction in the entry
+ * create_entry_block_alloca - Create an alloca instruction in the entry
  * block of the function.  This is used for mutable variables etc.
  */
-auto ASTToObjectVisitor::CreateEntryBlockAlloca(
-  llvm::Function* fn, llvm::StringRef var_name) -> llvm::AllocaInst* {
-  llvm::IRBuilder<> TmpB(&fn->getEntryBlock(), fn->getEntryBlock().begin());
-  return TmpB.CreateAlloca(ArxLLVM::FLOAT_TYPE, nullptr, var_name);
+auto ASTToObjectVisitor::create_entry_block_alloca(
+  llvm::Function* fn, llvm::StringRef var_name, std::string type_name)
+  -> llvm::AllocaInst* {
+  llvm::IRBuilder<> tmp_builder(
+    &fn->getEntryBlock(), fn->getEntryBlock().begin());
+  return tmp_builder.CreateAlloca(
+    ArxLLVM::get_data_type(type_name), nullptr, var_name);
 }
 
 /**
@@ -165,7 +168,7 @@ auto ASTToObjectVisitor::visit(UnaryExprAST& expr) -> void {
  *
  */
 auto ASTToObjectVisitor::visit(BinaryExprAST& expr) -> void {
-  //  Special case '=' because we don't want to emit the lhs as an
+  // Special case '=' because we don't want to emit the lhs as an
   // expression.*/
   if (expr.op == '=') {
     // Assignment requires the lhs to be an identifier.
@@ -188,13 +191,13 @@ auto ASTToObjectVisitor::visit(BinaryExprAST& expr) -> void {
     };
 
     // Look up the name.//
-    llvm::Value* Variable = ArxLLVM::named_values[var_lhs->get_name()];
-    if (!Variable) {
+    llvm::Value* variable = ArxLLVM::named_values[var_lhs->get_name()];
+    if (!variable) {
       this->result_val = LogErrorV("Unknown variable name");
       return;
     }
 
-    ArxLLVM::ir_builder->CreateStore(val, Variable);
+    ArxLLVM::ir_builder->CreateStore(val, variable);
     this->result_val = val;
   }
 
@@ -356,7 +359,9 @@ auto ASTToObjectVisitor::visit(ForExprAST& expr) -> void {
   llvm::Function* fn = ArxLLVM::ir_builder->GetInsertBlock()->getParent();
 
   // Create an alloca for the variable in the entry block.
-  llvm::AllocaInst* alloca = this->CreateEntryBlockAlloca(fn, expr.var_name);
+  // TODO: maybe it would be safe to change it to void
+  llvm::AllocaInst* alloca =
+    this->create_entry_block_alloca(fn, expr.var_name, "float");
 
   // Emit the start code first, without 'variable' in scope.
   expr.start.get()->accept(*this);
@@ -391,9 +396,9 @@ auto ASTToObjectVisitor::visit(ForExprAST& expr) -> void {
   // the current basic_block.  Note that we ignore the value computed by the
   // body, but don't allow an error.
   expr.body.get()->accept(*this);
-  llvm::Value* BodyVal = this->result_val;
+  llvm::Value* body_val = this->result_val;
 
-  if (!BodyVal) {
+  if (!body_val) {
     this->result_val = nullptr;
     return;
   }
@@ -460,7 +465,7 @@ auto ASTToObjectVisitor::visit(ForExprAST& expr) -> void {
  *
  */
 auto ASTToObjectVisitor::visit(VarExprAST& expr) -> void {
-  std::vector<llvm::AllocaInst*> OldBindings;
+  std::vector<llvm::AllocaInst*> old_bindings;
 
   llvm::Function* fn = ArxLLVM::ir_builder->GetInsertBlock()->getParent();
 
@@ -487,12 +492,14 @@ auto ASTToObjectVisitor::visit(VarExprAST& expr) -> void {
       InitVal = llvm::ConstantFP::get(*ArxLLVM::context, llvm::APFloat(0.0));
     }
 
-    llvm::AllocaInst* alloca = CreateEntryBlockAlloca(fn, var_name);
+    // TODO: replace "float" for the actual type_name from the argument
+    llvm::AllocaInst* alloca =
+      create_entry_block_alloca(fn, var_name, "float");
     ArxLLVM::ir_builder->CreateStore(InitVal, alloca);
 
     // Remember the old variable binding so that we can restore the
     // binding when we unrecurse.
-    OldBindings.push_back(ArxLLVM::named_values[var_name]);
+    old_bindings.push_back(ArxLLVM::named_values[var_name]);
 
     // Remember this binding.
     ArxLLVM::named_values[var_name] = alloca;
@@ -500,19 +507,19 @@ auto ASTToObjectVisitor::visit(VarExprAST& expr) -> void {
 
   // Codegen the body, now that all vars are in scope.
   expr.body.get()->accept(*this);
-  llvm::Value* BodyVal = this->result_val;
-  if (!BodyVal) {
+  llvm::Value* body_val = this->result_val;
+  if (!body_val) {
     this->result_val = nullptr;
     return;
   }
 
   // Pop all our variables from scope.
   for (unsigned i = 0, e = expr.var_names.size(); i != e; ++i) {
-    ArxLLVM::named_values[expr.var_names[i].first] = OldBindings[i];
+    ArxLLVM::named_values[expr.var_names[i].first] = old_bindings[i];
   }
 
   // Return the body computation.
-  this->result_val = BodyVal;
+  this->result_val = body_val;
 }
 
 /**
@@ -570,8 +577,9 @@ auto ASTToObjectVisitor::visit(FunctionAST& expr) -> void {
 
   for (auto& llvm_arg : fn->args()) {
     // Create an alloca for this variable.
+    // TODO: replace "float" for the actual type_name from the argument
     llvm::AllocaInst* alloca =
-      this->CreateEntryBlockAlloca(fn, llvm_arg.getName());
+      this->create_entry_block_alloca(fn, llvm_arg.getName(), "float");
 
     // Store the initial value into the alloca.
     ArxLLVM::ir_builder->CreateStore(&llvm_arg, alloca);
@@ -605,19 +613,7 @@ auto ASTToObjectVisitor::visit(FunctionAST& expr) -> void {
  *
  */
 auto ASTToObjectVisitor::initialize() -> void {
-  ArxLLVM::context = std::make_unique<llvm::LLVMContext>();
-  ArxLLVM::module =
-    std::make_unique<llvm::Module>("arx jit", *ArxLLVM::context);
-
-  /** Create a new builder for the module. */
-  ArxLLVM::ir_builder = std::make_unique<llvm::IRBuilder<>>(*ArxLLVM::context);
-
-  /* Data Types */
-  ArxLLVM::FLOAT_TYPE = llvm::Type::getFloatTy(*ArxLLVM::context);
-  ArxLLVM::DOUBLE_TYPE = llvm::Type::getDoubleTy(*ArxLLVM::context);
-  ArxLLVM::INT8_TYPE = llvm::Type::getInt8Ty(*ArxLLVM::context);
-  ArxLLVM::INT32_TYPE = llvm::Type::getInt32Ty(*ArxLLVM::context);
-  ArxLLVM::VOID_TYPE = llvm::Type::getVoidTy(*ArxLLVM::context);
+  ArxLLVM::initialize();
 }
 
 /**
@@ -674,15 +670,6 @@ auto compile_object(TreeAST& tree_ast) -> int {
   LOG(INFO) << "Starting main_loop";
 
   codegen->main_loop(tree_ast);
-
-  LOG(INFO) << "initialize Target";
-
-  // initialize the target registry etc.
-  llvm::InitializeAllTargetInfos();
-  llvm::InitializeAllTargets();
-  llvm::InitializeAllTargetMCs();
-  llvm::InitializeAllAsmParsers();
-  llvm::InitializeAllAsmPrinters();
 
   LOG(INFO) << "target_triple";
 
@@ -794,7 +781,7 @@ auto compile_object(TreeAST& tree_ast) -> int {
   std::cout << "ARX[INFO]: " << compiler_cmd << std::endl;
   int compile_result = system(compiler_cmd.c_str());
 
-  // ArxFile::delete_file(main_cpp_path);
+  ArxFile::delete_file(main_cpp_path);
 
   if (compile_result != 0) {
     llvm::errs() << "failed to compile and link object file";

--- a/src/codegen/ast-to-object.h
+++ b/src/codegen/ast-to-object.h
@@ -45,8 +45,8 @@ class ASTToObjectVisitor : public Visitor {
   virtual void clean() override;
 
   auto getFunction(std::string name) -> void;
-  auto CreateEntryBlockAlloca(
-    llvm::Function* the_function, llvm::StringRef var_name)
+  auto create_entry_block_alloca(
+    llvm::Function* fn, llvm::StringRef var_name, std::string type_name)
     -> llvm::AllocaInst*;
   auto main_loop(TreeAST&) -> void;
   auto initialize() -> void;

--- a/src/parser.h
+++ b/src/parser.h
@@ -80,14 +80,14 @@ class ExprAST {
     return loc.line;
   }
 
-  int getCol() const {
+  int get_col() const {
     return loc.col;
   }
 
   void accept(Visitor& visitor);
 
   virtual llvm::raw_ostream& dump(llvm::raw_ostream& out, int ind) {
-    return out << ':' << this->get_line() << ':' << this->getCol() << "\n";
+    return out << ':' << this->get_line() << ':' << this->get_col() << "\n";
   }
 };
 
@@ -124,10 +124,10 @@ class VariableExprAST : public ExprAST {
    * @param _type_name The variable type name
    */
   VariableExprAST(
-    SourceLocation _loc, std::string _name, std::string _type_name
-  ) :
-    ExprAST(_loc), name(std::move(_name)), type_name(std::move(_type_name))
-  {
+    SourceLocation _loc, std::string _name, std::string _type_name)
+      : ExprAST(_loc),
+        name(std::move(_name)),
+        type_name(std::move(_type_name)) {
     this->kind = ExprKind::VariableKind;
   }
 

--- a/src/parser.h
+++ b/src/parser.h
@@ -116,13 +116,18 @@ class FloatExprAST : public ExprAST {
 class VariableExprAST : public ExprAST {
  public:
   std::string name;
+  std::string type_name;
 
   /**
    * @param _loc The token location
    * @param _name The variable name
+   * @param _type_name The variable type name
    */
-  VariableExprAST(SourceLocation _loc, std::string _name)
-      : ExprAST(_loc), name(std::move(_name)) {
+  VariableExprAST(
+    SourceLocation _loc, std::string _name, std::string _type_name
+  ) :
+    ExprAST(_loc), name(std::move(_name)), type_name(std::move(_type_name))
+  {
     this->kind = ExprKind::VariableKind;
   }
 
@@ -253,7 +258,7 @@ class IfExprAST : public ExprAST {
     ExprAST::dump(out << "if", ind);
     this->cond->dump(indent(out, ind) << "cond:", ind + 1);
     this->then->dump(indent(out, ind) << "then:", ind + 1);
-    this->else_->dump(indent(out, ind) << "else_:", ind + 1);
+    this->else_->dump(indent(out, ind) << "else:", ind + 1);
     return out;
   }
 };
@@ -307,16 +312,21 @@ class ForExprAST : public ExprAST {
 class VarExprAST : public ExprAST {
  public:
   std::vector<std::pair<std::string, std::unique_ptr<ExprAST>>> var_names;
+  std::string type_name;
   std::unique_ptr<ExprAST> body;
 
   /**
-   * @param var_names Variable names
-   * @param body body of the variables
+   * @param _var_names Variable names
+   * @param _type_name Variables' type name
+   * @param _body body of the variables
    */
   VarExprAST(
     std::vector<std::pair<std::string, std::unique_ptr<ExprAST>>> _var_names,
+    std::string _type_name,
     std::unique_ptr<ExprAST> _body)
-      : var_names(std::move(_var_names)), body(std::move(_body)) {
+      : var_names(std::move(_var_names)),
+        type_name(std::move(_type_name)),
+        body(std::move(_body)) {
     this->kind = ExprKind::VarKind;
   }
 
@@ -341,18 +351,24 @@ class PrototypeAST : public ExprAST {
  public:
   std::string name;
   std::vector<std::unique_ptr<VariableExprAST>> args;
+  std::string type_name;
   int line;
 
   /**
    * @param _loc The token location
    * @param _name The prototype name
+   * @param _type_name The prototype return type
    * @param _args The prototype arguments
    */
   PrototypeAST(
     SourceLocation _loc,
     std::string _name,
+    std::string _type_name,
     std::vector<std::unique_ptr<VariableExprAST>>&& _args)
-      : name(std::move(_name)), args(std::move(_args)), line(_loc.line) {
+      : name(std::move(_name)),
+        type_name(std::move(_type_name)),
+        args(std::move(_args)),
+        line(_loc.line) {
     this->kind = ExprKind::PrototypeKind;
   }
 


### PR DESCRIPTION
<!-- Describe what this PR aims to resolve. E.g. This PR aims to ...  -->
* Add initial support for datatypes, using `float` as the only option for now.
* Rename some CamelCase variable names to snake_case.
* Initialize all ArxLLVM variables in just one place: `ArxLLVM::initialize` 
* Use `,` to separate parameters in the prototype declaration.

<!-- Which issue this PR aims to resolve or fix. E.g. This PR resolves #... -->

# PR Checklist

Ensure that:

- it includes tests.
- the tests for your implementation are executed on CI.
- it includes documentation
- the PR's title is according to the [semantic-release pattern][semantic-release-message] and
  [Conventional Commits](https://www.conventionalcommits.org).
  - `build`: Changes that affect the build system or external dependencies (example scopes: cmake, meson, etc)
  - `ci`: Changes to our CI configuration files and scripts (examples: CircleCi, SauceLabs)
  - `docs`: Documentation only changes
  - `perf`: A code change that improves performance
  - `refactor`: A code change that neither fixes a bug nor adds a feature
  - `test`: Adding missing tests or correcting existing tests
  - `chore`: Can be used as a generic task for tasks such as CI, test, support tasks or any other task that is not user facing task.
  - `feat`: is used for a new feature or when a existent one is improved.
  - `fix`: is used when a bug is fixed.
  - `fix!` or `feat!`: is used when there is a compatibility break.
- pre-commit hooks were executed locally


<!-- Add any other extra information that would help to understand the changes proposed by the PR -->


[semantic-release-message]: https://github.com/semantic-release/semantic-release/blob/master/README.md#commit-message-format "Semantic Release Commit Message Format"
